### PR TITLE
updates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ pbdb_map_occur (canidae, res= 2)
 Returns a map and a raster object with the number of different species, genera, family, etc. per cell.
 
 ```coffee
-pbdb_map_richness (data, res= 3, rank="species")
+pbdb_map_richness (canidae, res= 3, rank="species")
 ``` 
 
 ## Meta


### PR DESCRIPTION
Great package!!!!!

Two minor updates to the README:

(1) load the maps and raster packages.  The functions that depend on these do not load them, and throw errors.  For example, if I don't load the `raster` package and try to run `pbdb_map_richness()`, I get the following error 

```
Error in as.double(y) : 
  cannot coerce type 'S4' to vector of type 'double'
```

(2) fix typo in name of data argument for `pbdb_map_richness()`, to be consistent with other examples. 
