### PR TITLE
Correct index in .parse_raw_data

### DIFF
--- a/R/network.R
+++ b/R/network.R
@@ -53,7 +53,7 @@
 .parse_raw_data<-function(raw_data){
 
 	data_list <- fromJSON(raw_data)
-	df <- .make_data_frame(data_list[[1]])
+	df <- .make_data_frame(data_list[[2]])
 	df	
 }
 


### PR DESCRIPTION
I'm using `paleobioDB` v.0.3 installed from CRAN with `install.packages` on Linux using both Emacs and bash for running R v.3.3.1. I found a bug when running `pbdb_occurrences` both by using custom calls and finally with the example call in `?pbdb_occurrences`. After debugging the high-level function as well as low-level "dot" functions I found that `.parse_raw_data` was using the wrong index for `data_list`. This might be caused by the API providing further information previously missing (elapsed_time 0.0797) that ended up as the first element after calling `data_list <- fromJSON(raw_data)`.

The data frame returned by `pbdb_occurrences` is currently as follows:

```r
> canidae <- pbdb_occurrences(limit = "all", vocab = "pbdb", base_name = "Canidae", 
    show = c("coords", "phylo", "ident"))
> canidae
  reg_list[1]
1      0.0797
```

During debugging I found that using `data_list[[2]]` instead of `data_list[[1]]` returns the right data frame:

```r
Browse[5]> df2 <- .make_data_frame(data_list[[2]])
Browse[5]> ls()
[1] "data_list" "df"        "df2"       "raw_data" 
Browse[5]> str(df2)
'data.frame':	5850 obs. of  33 variables:
 $ occurrence_no : num  117266 117266 150070 150070 176227 ...
 $ record_type   : Factor w/ 1 level "occurrence": 1 1 1 1 1 1 1 1 1 1 ...
 $ collection_no : num  9070 9070 13293 13293 16626 ...
 $ taxon_name    : Factor w/ 449 levels "Cynodictis lacustris",..: 1 1 2 2 3 3 4 4 5 5 ...
 $ taxon_rank    : Factor w/ 6 levels "species","genus",..: 1 1 2 2 2 2 1 1 2 2 ...
 $ taxon_no      : num  41276 41276 41204 41204 41217 ...
# output for str truncated because of length
```

Below I provide the complete debugging output that allowed to detect the error. Hope this solves the bug.

Cheers,

Gustavo A. Ballen


# Complete debugging

```r
> debug(pbdb_occurrences)
> canidae <- pbdb_occurrences(limit="all", vocab= "pbdb", base_name="Canidae", show=c("coords", "phylo", "ident"))
debugging in: pbdb_occurrences(limit = "all", vocab = "pbdb", base_name = "Canidae", 
    show = c("coords", "phylo", "ident"))
debug: {
    l <- list(...)
    .pbdb_query("occs/list", query = l)
}
Browse[2]> debug(.pbdb_query)
Browse[2]> debug(.get_data_from_uri)
Browse[2]> debug(.parse_raw_data)
Browse[2]> 
debug: l <- list(...)
Browse[2]> 
debug: .pbdb_query("occs/list", query = l)
Browse[2]> 
debugging in: .pbdb_query("occs/list", query = l)
debug: {
    query <- lapply(query, .implode_to_string)
    uri <- .build_uri(endpoint, query = query)
    df <- .get_data_from_uri(uri)
    df
}
Browse[3]> 
debug: query <- lapply(query, .implode_to_string)
Browse[3]> 
debug: uri <- .build_uri(endpoint, query = query)
Browse[3]> 
debug: df <- .get_data_from_uri(uri)
Browse[3]> 
debugging in: .get_data_from_uri(uri)
debug: {
    response <- RCurl::getURL(uri, header = TRUE)
    raw_data <- .extract_response_body(response)
    df <- .parse_raw_data(raw_data)
    df
}
Browse[4]> 
debug: response <- RCurl::getURL(uri, header = TRUE)
Browse[4]> 
debug: raw_data <- .extract_response_body(response)
Browse[4]> 
debug: df <- .parse_raw_data(raw_data)
Browse[4]> 
debugging in: .parse_raw_data(raw_data)
debug: {
    data_list <- fromJSON(raw_data)
    df <- .make_data_frame(data_list[[1]])
    df
}
Browse[5]> 
debug: data_list <- fromJSON(raw_data)
Browse[5]> 
debug: df <- .make_data_frame(data_list[[1]])
Browse[5]> 
debugging in: .make_data_frame(data_list[[1]])
debug: {
    df <- as.data.frame(reg_list[1])
    len <- length(reg_list)
    if (len < 2) {
        return(df)
    }
    for (reg in reg_list[2:len]) {
        df <- smartbind(df, reg)
    }
    df
}
Browse[6]> 
debug: df <- as.data.frame(reg_list[1])
Browse[6]> 
debug: len <- length(reg_list)
Browse[6]> 
debug: if (len < 2) {
    return(df)
}
Browse[6]> 
debug: return(df)
Browse[6]> 
exiting from: .make_data_frame(data_list[[1]])
debug: df
Browse[5]> undebug(.make_data_frame)
Browse[5]> ls()
[1] "data_list" "df"        "raw_data" 
Browse[5]> str(df)
'data.frame':	1 obs. of  1 variable:
 $ reg_list[1]: num 0.00335
Browse[5]> df2 <- .make_data_frame(data_list[[2]])
Browse[5]> ls()
[1] "data_list" "df"        "df2"       "raw_data" 
Browse[5]> str(df2)
'data.frame':	5850 obs. of  33 variables:
 $ occurrence_no : num  117266 117266 150070 150070 176227 ...
 $ record_type   : Factor w/ 1 level "occurrence": 1 1 1 1 1 1 1 1 1 1 ...
 $ collection_no : num  9070 9070 13293 13293 16626 ...
 $ taxon_name    : Factor w/ 449 levels "Cynodictis lacustris",..: 1 1 2 2 3 3 4 4 5 5 ...
 $ taxon_rank    : Factor w/ 6 levels "species","genus",..: 1 1 2 2 2 2 1 1 2 2 ...
 $ taxon_no      : num  41276 41276 41204 41204 41217 ...
 $ matched_name  : Factor w/ 209 levels "Cynodictis","Cuon",..: 1 1 2 2 3 3 4 4 3 3 ...
 $ matched_rank  : Factor w/ 7 levels "genus","species",..: 1 1 1 1 1 1 2 2 1 1 ...
 $ matched_no    : num  41276 41276 41204 41204 41217 ...
 $ early_interval: Factor w/ 66 levels "Late Eocene",..: 1 1 2 2 3 3 4 4 5 5 ...
 $ early_age     : num  37.2 37.2 0.781 0.781 46.2 46.2 46.2 46.2 40.4 40.4 ...
 $ late_age      : num  33.9 33.9 0.0117 0.0117 40.4 40.4 40.4 40.4 33.9 33.9 ...
 $ reference_no  : num  11154 11154 4412 4412 1139 ...
 $ lng           : num  -1.09 -1.09 111.57 111.57 -107.6 ...
 $ lat           : num  50.7 50.7 22.8 22.8 50.2 ...
 $ genus         : Factor w/ 57 levels "Cynodictis","Cuon",..: 1 1 2 2 3 3 4 4 3 3 ...
 $ genus_no      : num  41276 41276 41204 41204 41217 ...
 $ family        : Factor w/ 1 level "Canidae": 1 1 1 1 1 1 1 1 1 1 ...
 $ family_no     : num  41189 41189 41189 41189 41189 ...
 $ order         : Factor w/ 1 level "Carnivora": 1 1 1 1 1 1 1 1 1 1 ...
 $ order_no      : num  36905 36905 36905 36905 36905 ...
 $ class         : Factor w/ 1 level "Mammalia": 1 1 1 1 1 1 1 1 1 1 ...
 $ class_no      : num  36651 36651 36651 36651 36651 ...
 $ phylum        : Factor w/ 1 level "Chordata": 1 1 1 1 1 1 1 1 1 1 ...
 $ phylum_no     : num  33815 33815 33815 33815 33815 ...
 $ genus_name    : Factor w/ 70 levels "Cynodictis","Cuon",..: 1 1 2 2 3 3 4 4 3 3 ...
 $ species_name  : Factor w/ 229 levels "lacustris","sp.",..: 1 1 2 2 2 2 3 3 2 2 ...
 $ late_interval : Factor w/ 25 levels "Late Pleistocene",..: NA NA 1 1 NA NA NA NA 2 2 ...
 $ reid_no       : num  NA NA NA NA 3083 ...
 $ genus_reso    : Factor w/ 5 levels "?","\"","cf.",..: NA NA NA NA NA NA NA NA 1 1 ...
 $ species_reso  : Factor w/ 6 levels "cf.","n. sp.",..: NA NA NA NA NA NA NA NA NA NA ...
 $ subgenus_name : Factor w/ 4 levels "Xenocyon","Thos",..: NA NA NA NA NA NA NA NA NA NA ...
 $ subgenus_reso : Factor w/ 1 level "?": NA NA NA NA NA NA NA NA NA NA ...
Browse[5]> 
exiting from: .parse_raw_data(raw_data)
debug: df
Browse[4]> 
exiting from: .get_data_from_uri(uri)
debug: df
Browse[3]> 
exiting from: .pbdb_query("occs/list", query = l)
exiting from: pbdb_occurrences(limit = "all", vocab = "pbdb", base_name = "Canidae", 
    show = c("coords", "phylo", "ident"))
```