### PR TITLE
change travis file to use newer R lang setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,6 @@
-# Sample .travis.yml for R projects from https://github.com/craigcitro/r-travis
-
-language: c
-
-before_install:
-  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
-  - chmod 755 ./travis-tool.sh
-  - ./travis-tool.sh bootstrap
-
-install:
-  - ./travis-tool.sh install_deps
-
-script: ./travis-tool.sh run_tests
-
-on_failure:
-  - ./travis-tool.sh dump_logs
+language: r
+sudo: false
+cache: packages
 
 notifications:
   email:


### PR DESCRIPTION
and `cache: packages`, `sudo: false` to speed up builds

hey @SaraVarela   - going through all ropensci repos trying to speed up Travis builds by using container based builds whenever possible 

the build https://travis-ci.org/ropensci/paleobioDB/builds/209102513 isn't faster than the others on the first run, but should be faster the next time since deps are cached

docs for R language on travis https://docs.travis-ci.com/user/languages/r