### PR TITLE
Fix smartbind

### DIFF
--- a/R/network.R
+++ b/R/network.R
@@ -77,7 +77,7 @@
     if (first_line) {
       df<- as.data.frame(reg)
     } else {
-      df<- smartbind(df, reg)
+      df<- smartbind(df, as.data.frame(reg))
     }
     
     first_line <- FALSE


### PR DESCRIPTION
Smartbind requires two data.frames as input, whereas the package was trying to bind a data.frame and a list (I'm guessing this used to work). So this just converts the list to a data.frame inline.

Fixes #34.