### PR TITLE
Air For R Code Formatting

### DIFF
--- a/.github/workflows/format-air-check.yaml
+++ b/.github/workflows/format-air-check.yaml
@@ -1,0 +1,48 @@
+###############################################################################
+# OVERVIEW
+###############################################################################
+# The following is a workflow derived from
+# https://github.com/posit-dev/setup-air/blob/main/examples/format-check.yaml
+# that suggests edits for the air R-code formatter (see air.toml) for more
+# information. The author installed air on mac via:
+# curl -LsSf https://github.com/posit-dev/air/releases/
+# latest/download/air-installer.sh | sh
+#
+# Description:
+#
+# This runs air format . --check on every push to main and on every pull
+# request. This is a very simple action that fails if any files would be
+# reformatted. When this happens, reformat locally using air format . or
+# the Air: Format Workspace Folder command in VS Code or Positron, and commit
+# and push the results.
+#
+# Note: The author believes that it's simpler to batch fixes w/ locally
+# with the checker rather than many small commits w/ the suggester.
+#
+# Links:
+#
+# Air GitHub Page: https://github.com/posit-dev/air
+# Air Configuration: https://posit-dev.github.io/air/configuration.html
+# Air Actions: https://posit-dev.github.io/air/integration-github-actions.html
+###############################################################################
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: format-air-check.yaml
+
+permissions: read-all
+
+jobs:
+  format-check:
+    name: format-air-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install
+        uses: posit-dev/setup-air@v1
+
+      - name: Check
+        run: air format . --check

--- a/.github/workflows/format-air-check.yaml
+++ b/.github/workflows/format-air-check.yaml
@@ -3,10 +3,6 @@
 ###############################################################################
 # The following is a workflow derived from
 # https://github.com/posit-dev/setup-air/blob/main/examples/format-check.yaml
-# that suggests edits for the air R-code formatter (see air.toml) for more
-# information. The author installed air on mac via:
-# curl -LsSf https://github.com/posit-dev/air/releases/
-# latest/download/air-installer.sh | sh
 #
 # Description:
 #
@@ -15,9 +11,10 @@
 # reformatted. When this happens, reformat locally using air format . or
 # the Air: Format Workspace Folder command in VS Code or Positron, and commit
 # and push the results.
-#
-# Note: The author believes that it's simpler to batch fixes w/ locally
-# with the checker rather than many small commits w/ the suggester.
+# 
+# To install air on MacOS or Linux:
+# curl -LsSf https://github.com/posit-dev/air/releases/latest/download/
+# air-installer.sh | sh
 #
 # Links:
 #

--- a/R/network.R
+++ b/R/network.R
@@ -11,11 +11,13 @@
 #'   "data1.1" or "data1.2"
 #' @returns A URL to perform an HTTP GET request.
 #' @noRd
-.build_uri <- function(endpoint,
-                       query = list(),
-                       api_base = "https://paleobiodb.org",
-                       format = "json",
-                       data_serv = "data1.2") {
+.build_uri <- function(
+  endpoint,
+  query = list(),
+  api_base = "https://paleobiodb.org",
+  format = "json",
+  data_serv = "data1.2"
+) {
   uri <- paste(api_base, data_serv, endpoint, sep = "/")
   uri <- paste(uri, format, sep = ".")
   query_str <- .build_query_string(query)

--- a/R/pbdb_geographic_functions.R
+++ b/R/pbdb_geographic_functions.R
@@ -10,7 +10,10 @@
   margins <- c(5.1, 0, 0, 0)
   maps::map(type = "n", mar = margins, ...)
   rect(
-    par("usr")[1], par("usr")[3], par("usr")[2], par("usr")[4],
+    par("usr")[1],
+    par("usr")[3],
+    par("usr")[2],
+    par("usr")[4],
     col = col_ocean
   )
   maps::map(col = col_int, fill = TRUE, mar = margins, add = TRUE, ...)
@@ -41,9 +44,14 @@
   lg_vals <- as.integer(seq(min(y1$Occur), max(y1$Occur), length.out = n))
   legend(
     "bottom",
-    col = cols, legend = lg_vals, pch = pch, bg = "white",
-    horiz = TRUE, inset = 0.01,
-    title = "Occurrences", ...
+    col = cols,
+    legend = lg_vals,
+    pch = pch,
+    bg = "white",
+    horiz = TRUE,
+    inset = 0.01,
+    title = "Occurrences",
+    ...
   )
 }
 
@@ -89,9 +97,16 @@
 #'     main = "Canis"
 #'   )
 #' }
-pbdb_map <- function(data, col_int = "white", pch = 19, col_ocean = "black",
-                     main = NULL, col_point = c("light blue", "blue"),
-                     do_plot = TRUE, ...) {
+pbdb_map <- function(
+  data,
+  col_int = "white",
+  pch = 19,
+  col_ocean = "black",
+  main = NULL,
+  col_point = c("light blue", "blue"),
+  do_plot = TRUE,
+  ...
+) {
   if (!all(c("lat", "lng") %in% names(data))) {
     err_msg <- strwrap(
       paste(
@@ -125,7 +140,10 @@ pbdb_map <- function(data, col_int = "white", pch = 19, col_ocean = "black",
   rect(
     # Subtract a little bit from the right side of the ocean rectangle
     # to avoid overlap with the raster legend
-    par("usr")[1], par("usr")[3], par("usr")[2] - 3, par("usr")[4],
+    par("usr")[1],
+    par("usr")[3],
+    par("usr")[2] - 3,
+    par("usr")[4],
     col = col_ocean
   )
   maps::map(col = col_int, fill = TRUE, mar = margins, add = TRUE, ...)
@@ -147,8 +165,15 @@ pbdb_map <- function(data, col_int = "white", pch = 19, col_ocean = "black",
   plot(r, col = adjustcolor(pal(50), alpha.f = 0.8), add = TRUE, ...)
 }
 
-.plot_raster_rich <- function(r, col_eff, col_ocean, col_int,
-                              res, lg_title, ...) {
+.plot_raster_rich <- function(
+  r,
+  col_eff,
+  col_ocean,
+  col_int,
+  res,
+  lg_title,
+  ...
+) {
   opar <- par(oma = c(0, 0, 0, 5.1))
   on.exit(par(opar))
   .add_col_ocean_2(col_ocean, col_int, ...)
@@ -194,13 +219,15 @@ pbdb_map <- function(data, col_int = "white", pch = 19, col_ocean = "black",
 #'   ## Get the raster object without plotting it
 #'   pbdb_map_occur(data, res = 3, do_plot = FALSE)
 #' }
-pbdb_map_occur <- function(data,
-                           res = 5,
-                           col_int = "white",
-                           col_ocean = "black",
-                           col_eff = c("light blue", "blue"),
-                           do_plot = TRUE,
-                           ...) {
+pbdb_map_occur <- function(
+  data,
+  res = 5,
+  col_int = "white",
+  col_ocean = "black",
+  col_eff = c("light blue", "blue"),
+  do_plot = TRUE,
+  ...
+) {
   if (!all(c("lat", "lng") %in% names(data))) {
     stop(
       "Invalid data input. ",
@@ -212,7 +239,11 @@ pbdb_map_occur <- function(data,
   r <- .rasterize_coords(y, res, ...)
   if (do_plot) {
     .plot_raster_rich(
-      r, col_eff, col_ocean, col_int, res,
+      r,
+      col_eff,
+      col_ocean,
+      col_int,
+      res,
       lg_title = "Number of records",
       ...
     )
@@ -261,7 +292,11 @@ pbdb_map_occur <- function(data,
   ranks <- data.frame(
     rank = c("genus", "family", "order", "class", "phylum"),
     accepted_rank = c(
-      "genus_no", "family_no", "order_no", "class_no", "phylum_no"
+      "genus_no",
+      "family_no",
+      "order_no",
+      "class_no",
+      "phylum_no"
     ),
     rnk = c("gnn", "fmn", "odn", "cln", "phn")
   )
@@ -338,20 +373,26 @@ pbdb_map_occur <- function(data,
 #'   ## Get the raster object without plotting the map
 #'   pbdb_map_richness(data, res = 8, rank = "family", do_plot = FALSE)
 #' }
-pbdb_map_richness <- function(data,
-                              rank = c("species", "genus", "family",
-                                       "order", "class", "phylum"),
-                              do_plot = TRUE,
-                              res = 5,
-                              col_int = "white",
-                              col_ocean = "black",
-                              col_rich = c("light blue", "blue"),
-                              title = "Taxonomic richness",
-                              ...) {
+pbdb_map_richness <- function(
+  data,
+  rank = c("species", "genus", "family", "order", "class", "phylum"),
+  do_plot = TRUE,
+  res = 5,
+  col_int = "white",
+  col_ocean = "black",
+  col_rich = c("light blue", "blue"),
+  title = "Taxonomic richness",
+  ...
+) {
   rank <- match.arg(rank)
 
   pbdb_fields <- c(
-    "accepted_no", "genus_no", "family_no", "order_no", "class_no", "phylum_no"
+    "accepted_no",
+    "genus_no",
+    "family_no",
+    "order_no",
+    "class_no",
+    "phylum_no"
   )
   com_fields <- c("tid", "gnn", "fmn", "odn", "cln", "phn")
 
@@ -376,7 +417,11 @@ pbdb_map_richness <- function(data,
 
   if (do_plot) {
     .plot_raster_rich(
-      r, col_rich, col_ocean, col_int, res,
+      r,
+      col_rich,
+      col_ocean,
+      col_int,
+      res,
       lg_title = title,
       ...
     )

--- a/R/pbdb_taxonomic_functions.R
+++ b/R/pbdb_taxonomic_functions.R
@@ -18,9 +18,7 @@
 #'   )
 #'   pbdb_subtaxa(canidae_quat)
 #' }
-pbdb_subtaxa <- function(data,
-                         do_plot = TRUE,
-                         col = "#0000FF") {
+pbdb_subtaxa <- function(data, do_plot = TRUE, col = "#0000FF") {
   species <- nrow(
     pbdb_temp_range(data = data, rank = "species", do_plot = FALSE)
   )

--- a/R/pbdb_temporal_functions.R
+++ b/R/pbdb_temporal_functions.R
@@ -15,8 +15,10 @@
 #'   pbdb_temporal_resolution(data)
 #' }
 pbdb_temporal_resolution <- function(data, do_plot = TRUE) {
-  if (!all(c("max_ma", "min_ma") %in% names(data)) &&
-        !all(c("eag", "lag") %in% names(data))) {
+  if (
+    !all(c("max_ma", "min_ma") %in% names(data)) &&
+      !all(c("eag", "lag") %in% names(data))
+  ) {
     err_msg <- strwrap(
       paste(
         "No temporal information found in the provided data.frame.",
@@ -34,10 +36,19 @@ pbdb_temporal_resolution <- function(data, do_plot = TRUE) {
   tr <- list(summary = summary(diff), temporal_resolution = diff)
 
   if (do_plot) {
-    hist(unlist(tr[[2]]), freq = TRUE, col = "#0000FF", border = FALSE,
-         xlim = c(max(unlist(tr[[2]]), na.rm = TRUE), 0),
-         breaks = 50, xlab = "Temporal resolution of the data (Ma)",
-         main = "", col.lab = "grey30", col.axis = "grey30", cex.axis = 0.8)
+    hist(
+      unlist(tr[[2]]),
+      freq = TRUE,
+      col = "#0000FF",
+      border = FALSE,
+      xlim = c(max(unlist(tr[[2]]), na.rm = TRUE), 0),
+      breaks = 50,
+      xlab = "Temporal resolution of the data (Ma)",
+      main = "",
+      col.lab = "grey30",
+      col.axis = "grey30",
+      cex.axis = 0.8
+    )
   }
 
   tr
@@ -71,12 +82,13 @@ pbdb_temporal_resolution <- function(data, do_plot = TRUE) {
 #'   )
 #'   pbdb_temp_range(canis_quaternary, rank = "species", names = FALSE)
 #' }
-pbdb_temp_range <- function(data,
-                            rank = c("species", "genus", "family",
-                                     "order", "class", "phylum"),
-                            col = "#0000FF",
-                            names = TRUE,
-                            do_plot = TRUE) {
+pbdb_temp_range <- function(
+  data,
+  rank = c("species", "genus", "family", "order", "class", "phylum"),
+  col = "#0000FF",
+  names = TRUE,
+  do_plot = TRUE
+) {
   rank <- match.arg(rank)
   temporal_range <- .extract_temporal_range(data, rank)
 
@@ -87,10 +99,13 @@ pbdb_temp_range <- function(data,
     right_margin <- max(nchar(row.names(t_range))) * 0.2
     opar <- par(mar = c(4, 1, 1, right_margin))
     on.exit(par(opar))
-    plot(c(min(t_range$min), max(t_range$max)),
+    plot(
+      c(min(t_range$min), max(t_range$max)),
       c(0, nrow(t_range)),
-      type = "n", axes = FALSE,
-      xlab = "Time (Ma)", ylab = "",
+      type = "n",
+      axes = FALSE,
+      xlab = "Time (Ma)",
+      ylab = "",
       xlim = c(max(t_range$max), min(t_range$min))
     )
     segments(
@@ -105,9 +120,13 @@ pbdb_temp_range <- function(data,
     axis(1, col = "gray30", cex.axis = 0.8)
     if (names) {
       text(
-        x = t_range$min, y = t_range$pos,
+        x = t_range$min,
+        y = t_range$pos,
         labels = paste("  ", row.names(t_range)),
-        adj = c(0, 0.5), cex = 0.5, col = "gray30", xpd = NA
+        adj = c(0, 0.5),
+        cex = 0.5,
+        col = "gray30",
+        xpd = NA
       )
     }
   }
@@ -117,8 +136,12 @@ pbdb_temp_range <- function(data,
 
 .extract_temporal_range <- function(data, rank) {
   col_abbr <- c(
-    accepted_name = "tna", genus = "gnl", family = "fml",
-    order = "odl", class = "cll", phylum = "phl"
+    accepted_name = "tna",
+    genus = "gnl",
+    family = "fml",
+    order = "odl",
+    class = "cll",
+    phylum = "phl"
   )
 
   if (!("phylum" %in% names(data) || "phl" %in% names(data))) {
@@ -201,15 +224,16 @@ pbdb_temp_range <- function(data,
 #'   )
 #'   pbdb_richness(data, rank = "species", res = 0.2, temporal_extent = c(0, 3))
 #'}
-pbdb_richness <- function(data,
-                          rank = c("species", "genus", "family",
-                                   "order", "class", "phylum"),
-                          res = 1,
-                          temporal_extent = c(0, 10),
-                          colour = "#0000FF30",
-                          bord = "#0000FF",
-                          ylab = "Richness",
-                          do_plot = TRUE) {
+pbdb_richness <- function(
+  data,
+  rank = c("species", "genus", "family", "order", "class", "phylum"),
+  res = 1,
+  temporal_extent = c(0, 10),
+  colour = "#0000FF30",
+  bord = "#0000FF",
+  ylab = "Richness",
+  do_plot = TRUE
+) {
   rank <- match.arg(rank)
   temporal_range <- pbdb_temp_range(data = data, rank = rank, do_plot = FALSE)
   te <- temporal_extent
@@ -237,34 +261,39 @@ pbdb_richness <- function(data,
     bottom_margin <- 5 + max(nchar(temporal_intervals)) / 3 + 0.4
     opar <- par(
       mar = c(bottom_margin, 5, 1, 5),
-      font.lab = 1, col.lab = "grey20",
-      col.axis = "grey50", cex.axis = 0.8
+      font.lab = 1,
+      col.lab = "grey20",
+      col.axis = "grey50",
+      cex.axis = 0.8
     )
     on.exit(par(opar))
     plot.window(
-      xlim = c(max(te), min(te)), xaxs = "i",
-      ylim = c(0, (max(richness[, 2])) + (max(richness[, 2]) / 10)), yaxs = "i"
+      xlim = c(max(te), min(te)),
+      xaxs = "i",
+      ylim = c(0, (max(richness[, 2])) + (max(richness[, 2]) / 10)),
+      yaxs = "i"
     )
 
     abline(v = seq(min(te), max(te), by = res), col = "grey90", lwd = 1)
     abline(
       h = seq(
-        0, max(richness[, 2]) + (max(richness[, 2]) / 10),
+        0,
+        max(richness[, 2]) + (max(richness[, 2]) / 10),
         by = (max(richness[, 2]) / 10)
       ),
-      col = "grey90", lwd = 1
+      col = "grey90",
+      lwd = 1
     )
     xx <- c(means[1], means, means[length(means)])
     yy <- c(0, richness[, 2], 0)
     polygon(xx, yy, col = colour, border = bord)
-    axis(1,
-      line = 1, las = 2, labels = temporal_intervals,
-      at = means
-    )
+    axis(1, line = 1, las = 2, labels = temporal_intervals, at = means)
     axis(2, line = 1, las = 1)
     mtext(
       "Million years before present",
-      line = floor(bottom_margin) - 2, adj = 1, side = 1
+      line = floor(bottom_margin) - 2,
+      adj = 1,
+      side = 1
     )
     mtext(ylab, line = 3.5, adj = 0, side = 2)
   }
@@ -320,16 +349,17 @@ pbdb_richness <- function(data,
 #'     temporal_extent = c(0, 10), res = 1
 #'   )
 #' }
-pbdb_orig_ext <- function(data,
-                          rank = c("species", "genus", "family",
-                                   "order", "class", "phylum"),
-                          temporal_extent,
-                          res,
-                          orig_ext = 1,
-                          colour = "#0000FF30",
-                          bord = "#0000FF",
-                          ylab = NULL,
-                          do_plot = TRUE) {
+pbdb_orig_ext <- function(
+  data,
+  rank = c("species", "genus", "family", "order", "class", "phylum"),
+  temporal_extent,
+  res,
+  orig_ext = 1,
+  colour = "#0000FF30",
+  bord = "#0000FF",
+  ylab = NULL,
+  do_plot = TRUE
+) {
   rank <- match.arg(rank)
   temporal_range <- pbdb_temp_range(data = data, rank = rank, do_plot = FALSE)
   te <- temporal_extent
@@ -373,8 +403,10 @@ pbdb_orig_ext <- function(data,
     on.exit(par(opar))
 
     plot.window(
-      xlim = c(xmx, xmn), xaxs = "i",
-      ylim = c(0, ymx), yaxs = "i"
+      xlim = c(xmx, xmn),
+      xaxs = "i",
+      ylim = c(0, ymx),
+      yaxs = "i"
     )
     abline(v = seq(xmn, xmx, by = res), col = "grey90", lwd = 1)
     abline(h = seq(0, ymx, by = (ymx / 10)), col = "grey90", lwd = 1)
@@ -387,8 +419,12 @@ pbdb_orig_ext <- function(data,
     mtext("Million years before present", line = 3, adj = 1, side = 1)
     if (is.null(ylab)) {
       rank_plurals <- c(
-        species = "species", genus = "genera", family = "families",
-        order = "orders", class = "classes", phylum = "phyla"
+        species = "species",
+        genus = "genera",
+        family = "families",
+        order = "orders",
+        class = "classes",
+        phylum = "phyla"
       )
       ylab <- paste("Number of", rank_plurals[rank])
     }

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,9 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+exclude = []
+default-exclude = true
+skip = []

--- a/tests/testthat/test-network.R
+++ b/tests/testthat/test-network.R
@@ -53,8 +53,19 @@ test_that(".make_data_frame() returns a data frame", {
   expect_s3_class(df, "data.frame")
   expect_identical(
     names(df),
-    c("oid", "cid", "tna", "rnk", "tid", "oei",
-      "eag", "lag", "rid", "lng", "lat")
+    c(
+      "oid",
+      "cid",
+      "tna",
+      "rnk",
+      "tid",
+      "oei",
+      "eag",
+      "lag",
+      "rid",
+      "lng",
+      "lat"
+    )
   )
 })
 

--- a/tests/testthat/test-queries_collections.R
+++ b/tests/testthat/test-queries_collections.R
@@ -17,7 +17,10 @@ test_that("pbdb_collections() returns a data frame with an id column", {
 test_that("pbdb_collections_geo() returns a data frame with an id column", {
   skip_if_offline("paleobiodb.org")
   response <- pbdb_collections_geo(
-    lngmin = 0.0, lngmax = 15.0, latmin = 0.0, latmax = 15.0,
+    lngmin = 0.0,
+    lngmax = 15.0,
+    latmin = 0.0,
+    latmax = 15.0,
     level = 2,
     vocab = "pbdb"
   )

--- a/tests/testthat/test-queries_err_warn.R
+++ b/tests/testthat/test-queries_err_warn.R
@@ -2,7 +2,9 @@ test_that("warnings returned from the API are reported", {
   skip_if_offline("paleobiodb.org")
   expect_warning(
     response <- pbdb_occurrences(
-      id = c(10, 11), vocab = "pbdb", show = c("class", "coodrs")
+      id = c(10, 11),
+      vocab = "pbdb",
+      show = c("class", "coodrs")
     ),
     regexp = "Your query to the PBDB API generated the following warnings:"
   )
@@ -35,7 +37,10 @@ test_that("valid queries that return no records produce a warning", {
 test_that("pbdb_collections_geo() requires a 'level' parameter", {
   expect_error(
     pbdb_collections_geo(
-      lngmin = 0.0, lngmax = 15.0, latmin = 0.0, latmax = 15.0
+      lngmin = 0.0,
+      lngmax = 15.0,
+      latmin = 0.0,
+      latmax = 15.0
     ),
     regexp = "Parameter \"level\" is required."
   )

--- a/tests/testthat/test-queries_measurements.R
+++ b/tests/testthat/test-queries_measurements.R
@@ -9,7 +9,9 @@ test_that("pbdb_specimen() returns a data frame with an id column", {
 test_that("pbdb_specimens() returns a data frame with an id column", {
   skip_if_offline("paleobiodb.org")
   response <- pbdb_specimens(
-    base_name = "Cetacea", interval = "Miocene", vocab = "pbdb"
+    base_name = "Cetacea",
+    interval = "Miocene",
+    vocab = "pbdb"
   )
   expect_s3_class(response, "data.frame")
   expect_true("specimen_no" %in% names(response))

--- a/tests/testthat/test-queries_references.R
+++ b/tests/testthat/test-queries_references.R
@@ -17,7 +17,9 @@ test_that("pbdb_references() returns a data frame with an id column", {
 test_that("pbdb_ref_occurrences() returns a data frame with an id column", {
   skip_if_offline("paleobiodb.org")
   response <- pbdb_ref_occurrences(
-    base_name = "Canis", ref_pubyr = 2000, vocab = "pbdb"
+    base_name = "Canis",
+    ref_pubyr = 2000,
+    vocab = "pbdb"
   )
   expect_s3_class(response, "data.frame")
   expect_true("reference_no" %in% names(response))

--- a/tests/testthat/test-queries_strata.R
+++ b/tests/testthat/test-queries_strata.R
@@ -1,7 +1,11 @@
 test_that("pbdb_strata() returns a data frame with time ranges", {
   skip_if_offline("paleobiodb.org")
   response <- pbdb_strata(
-    lngmin = 0, lngmax = 15, latmin = 0, latmax = 5, rank = "formation"
+    lngmin = 0,
+    lngmax = 15,
+    latmin = 0,
+    latmax = 5,
+    rank = "formation"
   )
   expect_s3_class(response, "data.frame")
   expect_true(all(c("eag", "lag") %in% names(response)))


### PR DESCRIPTION
This PR:

* Adds an `air.toml` file (configuration file for `air`).
* Adds changes made from running `air format .`
* Adds `format-air-check.yaml`, a GitHub action workflow that checks if `air` formatting changes need to be made (i.e. if the user has not yet ran `air format .`)

Why?

* Code across codebase adheres to same formatting standards.
* Code looks cleaner.

Context:

* Description: "an extremely fast R formatter." 
* Air Blog Post: <https://www.tidyverse.org/blog/2025/02/air/>
* Linux/MacOS Installation: `curl -LsSf https://github.com/posit-dev/air/releases/latest/download/air-installer.sh | sh`
* Air GitHub Page: <https://github.com/posit-dev/air>

The formats made in this PR are guided by the configuration specified in `air.toml` (also in the PR). The workflow for developers of `rphylopic` would be to (1) install `air`, (2) run `air format .` or `air format . --check` before committing, and (3) run `air format .` later if `format-check.yaml` finds R scripts that do not adhere to the format specifications.


<details markdown=1>

<summary> Air Configuration File </summary>



```

[format]
line-width = 80
indent-width = 2
indent-style = "space"
line-ending = "auto"
persistent-line-breaks = true
exclude = []
default-exclude = true
skip = []
```



</details>
